### PR TITLE
Update rsync command to copy without preserving permissions

### DIFF
--- a/notebooks/07_data_transfer.md
+++ b/notebooks/07_data_transfer.md
@@ -51,7 +51,7 @@ Be sure to replace everything in brackets `<` `>` with values specific to the da
 :::
 
 ```bash
-rsync -rlcP <your_unikey>@research-data-int.sydney.edu.au:/rds/PRJ-<rds_project>/<path_to_project_data> <pvc_mount_point>/<path_to_pvc_data>
+rsync -rlctP <your_unikey>@research-data-int.sydney.edu.au:/rds/PRJ-<rds_project>/<path_to_project_data> <pvc_mount_point>/<path_to_pvc_data>
 ```
 
 After you execute this command, you will be prompted for the password associated with your unikey to establish a connection to RDS. 
@@ -59,7 +59,7 @@ After you execute this command, you will be prompted for the password associated
 To copy data from the DGX to RDS, reverse the order of source and destination in the above command:
 
 ```bash
-rsync -rlcP <pvc_mount_point>/<path_to_pvc_data> <your_unikey>@research-data-int.sydney.edu.au:/rds/PRJ-<rds_project>/<path_to_project_data> 
+rsync -rlctP <pvc_mount_point>/<path_to_pvc_data> <your_unikey>@research-data-int.sydney.edu.au:/rds/PRJ-<rds_project>/<path_to_project_data> 
 ```
 
 The above rsync will also perform integrity checking using a *checksum*, comparing the original and copied files to make sure they are identical.


### PR DESCRIPTION
## Description

[DGXC-89](https://sydneyuni.atlassian.net/browse/DGXC-89): Stop rsync reporting permisiions errors when copying from DGX to RDS

## Changes

- Use `-avcP` flags for rsync so as not to try and preserve permissions between servers. This stops errors occuring on the RDS side when trying to change to unkown GID and UID
---

## Checklist

- [x] My changes build successfully with **Quarto** (`quarto preview` or `quarto render`)  
- [x] No broken links (`quarto check`)
- [x] Screenshots or diagrams updated (if applicable)  
- [x] Documented any new files in `_quarto.yml` or relevant index pages  
---

## How to View Changes

Pull the repo, change to the relevant branch and use `quarto preview` to view the marked-up version of the text in a browser window.
